### PR TITLE
Add More Meaningful Path Names to API Requests

### DIFF
--- a/backend/src/TaskManager.Api/Controllers/TaskController.cs
+++ b/backend/src/TaskManager.Api/Controllers/TaskController.cs
@@ -6,7 +6,7 @@ using TaskManager.Api.Services;
 namespace TaskManager.Api.Controllers
 {
     [ApiController]
-    [Route("api/[controller]s")]
+    [Route("api/[controller]s/")]
     public class TaskController : ControllerBase
     {
         private readonly ITaskService _svc;
@@ -15,16 +15,16 @@ namespace TaskManager.Api.Controllers
             _svc = svc;
         }
 
-        // GET: /tasks
-        [HttpGet]
+        // GET: /tasks/getTasks
+        [HttpGet("getTasks")]
         public async Task<ActionResult<IEnumerable<TaskItem>>> GetAll()
         {
             var list = await _svc.GetAllAsync();
             return Ok(list);
         }
 
-        // POST: /tasks
-        [HttpPost]
+        // POST: /tasks/createTask
+        [HttpPost("createTask")]
         public async Task<ActionResult<TaskItem>> Create(TaskItem newTask)
         {
             var created = await _svc.CreateAsync(newTask);
@@ -33,8 +33,8 @@ namespace TaskManager.Api.Controllers
                                    created);
         }
 
-        // PATCH: /tasks/{id}/toggle
-        [HttpPatch("{id}/toggle")]
+        // PATCH: /tasks/{id}/toggleTask
+        [HttpPatch("{id}/toggleTask")]
         public async Task<ActionResult<TaskItem>> Toggle(int id)
         {
             try
@@ -49,7 +49,7 @@ namespace TaskManager.Api.Controllers
         }
 
         // DELETE: /tasks/{id}
-        [HttpDelete("{id}")]
+        [HttpDelete("{id}/deleteTask")]
         public async Task<IActionResult> Delete(int id)
         {
             try

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,9 @@
-// import { TestAPIButtons } from "./components/TestApiWithButtons"
-import { useTasks } from "./context/TasksContext";
 import { TasksPage } from "./pages/TasksPage";
 
 function App() {
-  const {
-    tasks,
-    loading,
-    error,
-    addTask,
-    toggleCompletion,
-    removeTask,
-  } = useTasks();
-
-  if (loading) return <p>Loading…</p>;
-  if (error)   return <p>Error: {error.message}</p>;
-
   return (
     <div>
-      
-
-      <div>
-        <TasksPage />
-      </div>
+      <TasksPage />
     </div>
   );
 }

--- a/frontend/src/api/TaskController.ts
+++ b/frontend/src/api/TaskController.ts
@@ -16,13 +16,13 @@ const api = axios.create({
 })
 
 export const GetTasks = (): Promise<Task[]> =>
-    api.get<Task[]>('/tasks').then(res => res.data)
+    api.get<Task[]>('/tasks/getTasks').then(res => res.data)
 
 export const CreateTask = (t: string): Promise<Task> =>
-    api.post<Task>('/tasks', { title: t }).then(res => res.data)
+    api.post<Task>('/tasks/createTask', { title: t }).then(res => res.data)
 
 export const UpdateCompletionStatus = (id: number): Promise<Task> =>
-    api.patch<Task>(`/tasks/${id}/toggle`).then((res) => res.data);
+    api.patch<Task>(`/tasks/${id}/toggleTask`).then((res) => res.data);
 
 export const DeleteTask = (id: number): Promise<void> =>
-    api.delete(`/tasks/${id}`).then(() => {});
+    api.delete(`/tasks/${id}/deleteTask`).then(() => {});


### PR DESCRIPTION
Add More Meaningful Path Names to API Requests. Before when I was testing the requests from the browser's network tab, it didn't make any sense. Now the names are more aligned to what they are supposed to do.

- getTasks
- createTask
- toggleTask
- deleteTask